### PR TITLE
Add functionality needed for changelogging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject liftoff/korma "0.4.3-liftoff-1"
+(defproject liftoff/korma "0.4.3-liftoff-2"
   :description "Tasty SQL for Clojure"
   :url "http://github.com/korma/Korma"
   :mailing-list {:name "Korma Google Group"


### PR DESCRIPTION
Adds the following:
- A pre- and post- hook that are used to call our changelogging functions
- An upsert (really just the "insert" fallback for the upsert)--this will be replaced with a real upsert once we upgrade to the latest Postgres, but is needed for now to ensure that upserts are logged correctly.

Better names for both these features would be appreciated.