### PR TITLE
Run prepares with a *conn* context

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -533,7 +533,8 @@
 (defn exec
   "Execute a query map and return the results."
   [query]
-  (if (or (seq (:pre-side-effects query)) (seq (:post-side-effects query)))
+  (if (or (seq (:pre-side-effects query)) (seq (:post-side-effects query))
+          (-> query :ent :prepares seq))
     (db/with-db (or db/*current-db* (get query :db))
       (db/transaction
         (exec* query)))


### PR DESCRIPTION
In order to allow the following prepare method to work I had to make sure that such prepare methods are invoked in a context where `korma.db/*current-conn*` is initialized. Apparently it has been missed previously.

```
(defn prepare-array
  "Generate a prepare function to convert clojure collections into java.sql.Array."
  [column-name]
  (fn [row]
    (if-let [clj-seq (get row column-name)]
      (->> clj-seq
           (#(.createArrayOf
               (clojure.java.jdbc/get-connection korma.db/*current-conn*)
               "VARCHAR"
               (into-array %)))
           (assoc row column-name))
      row)))
```