### PR TITLE
Fix check for side effects

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject liftoff/korma "0.4.3-liftoff-3"
+(defproject liftoff/korma "0.4.3-liftoff-4"
   :description "Tasty SQL for Clojure"
   :url "http://github.com/korma/Korma"
   :mailing-list {:name "Korma Google Group"

--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -533,11 +533,15 @@
 (defn exec
   "Execute a query map and return the results."
   [query]
-  (if (or (seq (:pre-side-effects query)) (seq (:post-side-effects query))
+  (if (or (seq (get-in query [:ent :pre-side-effects]))
+          (seq (get-in query [:ent :post-side-effects]))
           (-> query :ent :prepares seq))
-    (db/with-db (or db/*current-db* (get query :db))
+    (if db/*current-conn*
       (db/transaction
-        (exec* query)))
+        (exec* query))
+      (db/with-db (or (:db query) @db/_default)
+        (db/transaction
+          (exec* query))))
     (exec* query)))
 
 (defn exec-raw

--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -257,6 +257,8 @@
 
 (defmacro transaction
   "Execute all queries within the body in a single transaction.
+  When executed in the context of existing connection will use that and properly nest transactions.
+  Otherwise it will fallback to default-connection.
   Optionally takes as a first argument a map to specify the :isolation and :read-only? properties of the transaction."
   {:arglists '([body] [options & body])}
   [& body]
@@ -288,9 +290,10 @@
       (jdbc/db-do-prepared *current-conn* sql-params))))
 
 (defmacro with-db
-  "Execute all queries within the body using the given db spec"
+  "Execute all queries within the body using the given db spec.
+  Breaks nested transactions! Use default-connection instead."
   [db & body]
-  `(jdbc/with-db-connection [conn# (korma.db/get-connection ~db)]
+  `(jdbc/with-db-connection [conn# (get-connection ~db)]
      (binding [*current-db* ~db
                *current-conn* conn#]
        ~@body)))


### PR DESCRIPTION
I've figured out that the check for pre and post side effects was not correct. It was checking for fields at a different level of nesting. This PR fixes it.

I only have to fix it because for elephant triggers I need each operation to be wrapped into a transaction. Wrapping it outside of korma is not practical.

UPDATE: `with-db` is destructive w.r.t. nested transactions. The solution I found is to avoid them as much as possible. `default-connection` is a preferred way to specify a db if no connection is opened yet.